### PR TITLE
Add workspace git sync as Docker sidecar container

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -23,3 +23,13 @@ BRAVE_SEARCH_API_KEY=
 # ─── GHCR (GitHub Container Registry) ─────────────────────────────────────────
 # Your GitHub username for pulling Docker images
 GHCR_USERNAME=
+
+# ─── Workspace Git Sync (optional) ──────────────────────────────────────────
+# Daily commit+push of ~/.openclaw/workspace to a private GitHub repo.
+# Create a PAT at: github.com/settings/tokens with 'repo' scope
+# Auto-enables when GIT_WORKSPACE_REPO is set
+GIT_WORKSPACE_REPO=your-username/openclaw-workspace
+GIT_WORKSPACE_BRANCH=auto
+GIT_WORKSPACE_TOKEN=
+# Cron schedule: minute hour day month weekday (default: daily at 4 AM UTC)
+GIT_WORKSPACE_SYNC_SCHEDULE=0 4 * * *

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,3 +19,16 @@ services:
     ports:
       - "127.0.0.1:${OPENCLAW_GATEWAY_PORT:-18789}:18789"
     command: openclaw gateway --bind lan --port 18789
+
+  workspace-sync:
+    image: ghcr.io/${GHCR_USERNAME}/openclaw-docker-config/workspace-sync:latest
+    restart: unless-stopped
+    environment:
+      GIT_WORKSPACE_REPO: ${GIT_WORKSPACE_REPO:-}
+      GIT_WORKSPACE_BRANCH: ${GIT_WORKSPACE_BRANCH:-auto}
+      GIT_WORKSPACE_TOKEN: ${GIT_WORKSPACE_TOKEN:-}
+      GIT_WORKSPACE_SYNC_SCHEDULE: ${GIT_WORKSPACE_SYNC_SCHEDULE:-0 4 * * *}
+    volumes:
+      - ${OPENCLAW_WORKSPACE_DIR:-/home/openclaw/.openclaw/workspace}:/workspace
+    profiles:
+      - sync

--- a/docker/workspace-sync/Dockerfile
+++ b/docker/workspace-sync/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.19
+
+RUN apk add --no-cache git bash
+
+COPY workspace-sync.sh /usr/local/bin/
+COPY entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/workspace-sync.sh /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["entrypoint.sh"]

--- a/docker/workspace-sync/entrypoint.sh
+++ b/docker/workspace-sync/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+# If repo is not configured, idle forever (don't restart-loop)
+if [[ -z "${GIT_WORKSPACE_REPO:-}" ]]; then
+    echo "[workspace-sync] GIT_WORKSPACE_REPO not set — idling"
+    exec sleep infinity
+fi
+
+# Volume is owned by host user (UID 1000), container runs as root
+git config --global --add safe.directory /workspace
+
+SCHEDULE="${GIT_WORKSPACE_SYNC_SCHEDULE:-0 4 * * *}"
+
+echo "[workspace-sync] Repo: $GIT_WORKSPACE_REPO"
+echo "[workspace-sync] Branch: ${GIT_WORKSPACE_BRANCH:-auto}"
+echo "[workspace-sync] Schedule: $SCHEDULE"
+echo ""
+
+# Run initial sync to verify credentials
+echo "[workspace-sync] Running initial sync..."
+workspace-sync.sh
+echo ""
+
+# Set up cron — pass env vars through to the cron job
+env > /tmp/workspace-sync.env
+echo "$SCHEDULE /usr/bin/env - \$(cat /tmp/workspace-sync.env | tr '\\n' ' ') /usr/local/bin/workspace-sync.sh >> /proc/1/fd/1 2>> /proc/1/fd/2" > /etc/crontabs/root
+
+echo "[workspace-sync] Cron configured, starting scheduler..."
+exec crond -f -l 2

--- a/scripts/build-and-push.sh
+++ b/scripts/build-and-push.sh
@@ -10,7 +10,7 @@ if [[ -z "${GHCR_USERNAME:-}" ]]; then
     exit 1
 fi
 
-IMAGE="ghcr.io/${GHCR_USERNAME}/openclaw-docker-config/openclaw-gateway"
+GHCR_PREFIX="ghcr.io/${GHCR_USERNAME}/openclaw-docker-config"
 TAG="${1:-latest}"
 SHA=$(git -C "$REPO_ROOT" rev-parse --short HEAD)
 
@@ -20,13 +20,29 @@ echo ""
 "$REPO_ROOT/scripts/check-secrets.sh"
 echo ""
 
-echo "==> Building image ..."
-echo "    Image: $IMAGE"
+# --- Gateway image ---
+GW_IMAGE="$GHCR_PREFIX/openclaw-gateway"
+echo "==> Building gateway image ..."
+echo "    Image: $GW_IMAGE"
 echo "    Tags:  $TAG, $SHA"
 echo ""
 
-docker buildx build --platform linux/amd64 -f "$REPO_ROOT/docker/Dockerfile" -t "$IMAGE:$TAG" -t "$IMAGE:$SHA" --push "$REPO_ROOT"
+docker buildx build --platform linux/amd64 -f "$REPO_ROOT/docker/Dockerfile" -t "$GW_IMAGE:$TAG" -t "$GW_IMAGE:$SHA" --push "$REPO_ROOT"
 
 echo ""
-echo "✓ Built and pushed $IMAGE:$TAG (linux/amd64)"
-echo "✓ Built and pushed $IMAGE:$SHA (linux/amd64)"
+echo "✓ Built and pushed $GW_IMAGE:$TAG (linux/amd64)"
+echo "✓ Built and pushed $GW_IMAGE:$SHA (linux/amd64)"
+
+# --- Workspace-sync image ---
+WS_IMAGE="$GHCR_PREFIX/workspace-sync"
+echo ""
+echo "==> Building workspace-sync image ..."
+echo "    Image: $WS_IMAGE"
+echo "    Tags:  $TAG, $SHA"
+echo ""
+
+docker buildx build --platform linux/amd64 -f "$REPO_ROOT/docker/workspace-sync/Dockerfile" -t "$WS_IMAGE:$TAG" -t "$WS_IMAGE:$SHA" --push "$REPO_ROOT/docker/workspace-sync"
+
+echo ""
+echo "✓ Built and pushed $WS_IMAGE:$TAG (linux/amd64)"
+echo "✓ Built and pushed $WS_IMAGE:$SHA (linux/amd64)"


### PR DESCRIPTION
## Description

Add optional workspace git sync as a Docker sidecar container. This automatically commits and pushes `~/.openclaw/workspace` on the VPS to a user-configured private GitHub repo on a cron schedule (default: daily at 4 AM UTC).

Key design decisions:
- **Containerized sidecar** — runs as a separate lightweight Alpine container alongside the gateway, managed via Docker Compose profiles
- **Auto-enable via config** — the deploy script detects `GIT_WORKSPACE_REPO` in `.env` and automatically starts/stops the sidecar (no manual enable/disable needed)
- **GHCR image** — the sidecar image is built and pushed to GHCR alongside the gateway image via `build-and-push.sh`
- **Built-in cron** — uses busybox `crond` inside the container; cron config lives in the container's filesystem and is recreated on each start
- **Graceful idle** — if `GIT_WORKSPACE_REPO` is empty, the container sleeps forever (no restart loops). (For safety, not actually used)
- Pushes to a configurable branch (default: `auto`), so users can manually merge to `main` via PR when ready

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

- [x] Built and pushed workspace-sync image to GHCR via `build-and-push.sh`
- [x] Deployed to VPS via `make bootstrap` + `make deploy` (proper workflow)
- [x] Verified sidecar starts automatically when `GIT_WORKSPACE_REPO` is set
- [x] Verified sidecar is stopped and removed when `GIT_WORKSPACE_REPO` is cleared + redeploy
- [x] Verified manual sync via `docker compose exec workspace-sync workspace-sync.sh`
- [x] Verified initial sync runs on container startup
- [x] Verified cron schedule is configured correctly
- [x] Verified `[SKIP] No changes to sync` when workspace has no changes
- [x] Tested with actual changes — successfully pushed to `auto` branch on GitHub

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Commented complex or non-obvious code
- [x] Updated documentation (README, comments, etc.)
- [x] No secrets or sensitive data committed
- [x] Tested changes work as expected

## Related Issues

N/A

## New Files

- `docker/workspace-sync/Dockerfile` — minimal Alpine image with git + bash + cron
- `docker/workspace-sync/entrypoint.sh` — sets up git safe.directory, runs initial sync, configures cron, starts crond
- `docker/workspace-sync/workspace-sync.sh` — git init/add/commit/push logic, reads config from env vars

## Modified Files

- `docker/docker-compose.yml` — added workspace-sync service with `profiles: [sync]`
- `docker/.env.example` — added `GIT_WORKSPACE_*` env vars and `GIT_WORKSPACE_SYNC_SCHEDULE`
- `scripts/build-and-push.sh` — now builds both gateway and workspace-sync images
- `README.md` — added "Workspace Git Sync" section and updated Docker Image Versioning

## Companion PR

Infra repo changes (Makefile targets, deploy.sh profile auto-detection): https://github.com/andreesg/openclaw-terraform-hetzner/pull/2

## Usage

```bash
# In .env (or infra repo's secrets/openclaw.env):
GIT_WORKSPACE_REPO=your-username/openclaw-workspace
GIT_WORKSPACE_BRANCH=auto
GIT_WORKSPACE_TOKEN=ghp_your_pat
GIT_WORKSPACE_SYNC_SCHEDULE=0 4 * * *

# Deploy — sidecar auto-enables when GIT_WORKSPACE_REPO is set:
make push-env && make deploy

# Manual sync (from infra repo):
make workspace-sync

# Disable — clear GIT_WORKSPACE_REPO and redeploy:
make push-env && make deploy
```
