### PR TITLE
(fix): :memo: openclaw-terraform-hetzner points to 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenClaw Docker Config
 
-Docker configuration and application setup for OpenClaw. Companion repository to [openclaw-terraform-hetzner](https://github.com/YOUR_USERNAME/openclaw-terraform-hetzner).
+Docker configuration and application setup for OpenClaw. Companion repository to [openclaw-terraform-hetzner](https://github.com/andreesg/openclaw-terraform-hetzner).
 
 **Note:** This is a minimal, generic configuration with only essential skills activated. You're encouraged to customize it by adding [ClawHub skills](https://clawhub.ai/) or creating your own custom skills (see [Working with Skills](#working-with-skills)).
 


### PR DESCRIPTION
### What

When someone clicks on the link in the README he/she is redirected to:

<img width="1108" height="375" alt="Screenshot 2026-02-16 at 10 35 23" src="https://github.com/user-attachments/assets/c75e1e7d-9a40-4ae9-a9db-5a7299cf06da" />


