### PR TITLE
Add GitHub integration (gh CLI + github skill)

### DIFF
--- a/config/skills-manifest.txt
+++ b/config/skills-manifest.txt
@@ -14,3 +14,6 @@ system-monitor
 
 # Conventional Commits — format commit messages properly
 conventional-commits
+
+# GitHub — interact with GitHub (issues, PRs, CI runs) via gh CLI
+github

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -16,6 +16,11 @@ OPENCLAW_GATEWAY_BIND=0.0.0.0
 OPENCLAW_CONFIG_DIR=/home/openclaw/.openclaw
 OPENCLAW_WORKSPACE_DIR=/home/openclaw/.openclaw/workspace
 
+# ─── GitHub ───────────────────────────────────────────────────────────────────
+# github.com/settings/tokens → Fine-grained or Classic PAT
+# Scopes needed: repo, workflow, read:org (for the github skill: PRs, issues, CI)
+GH_TOKEN=
+
 # ─── Brave Search ─────────────────────────────────────────────────────────────
 # brave.com/search/api (free tier)
 BRAVE_SEARCH_API_KEY=

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,6 +18,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tini \
   && rm -rf /var/lib/apt/lists/*
 
+# Install GitHub CLI (required by github skill)
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update && apt-get install -y --no-install-recommends gh \
+  && rm -rf /var/lib/apt/lists/*
+
 # Pin OpenClaw version for reproducible builds — bump explicitly when upgrading
 ARG OPENCLAW_VERSION=2026.2.6-3
 RUN npm install -g openclaw@${OPENCLAW_VERSION}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       OPENCLAW_GATEWAY_BIND: ${OPENCLAW_GATEWAY_BIND:-0.0.0.0}
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
       BRAVE_API_KEY: ${BRAVE_API_KEY}
+      GH_TOKEN: ${GH_TOKEN:-}
     volumes:
       - ${OPENCLAW_CONFIG_DIR:-/home/openclaw/.openclaw}:/home/node/.openclaw
       - ${OPENCLAW_WORKSPACE_DIR:-/home/openclaw/.openclaw/workspace}:/home/node/.openclaw/workspace


### PR DESCRIPTION
## Description

Add GitHub skill support so OpenClaw can interact with GitHub repos (PRs, issues, CI runs) via the `gh` CLI.

- **`gh` CLI** installed in the gateway Docker image
- **`github` skill** added to the skills manifest (auto-installed on startup via ClawHub)
- **`GH_TOKEN`** env var passed through to the gateway container

## Type of Change

- [ ] Bug fix (non-breaking change fixing an issue)
- [x] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

- [x] Verified `gh` CLI installed in gateway container (v2.86.0)
- [x] Verified `gh auth status` — authenticated via `GH_TOKEN` env var
- [x] Verified `gh repo list`, `gh pr list` work from inside the container
- [x] Verified `github` skill auto-installed via ClawHub on container startup

## Checklist

- [x] Code follows project style guidelines
- [x] Self-reviewed the code
- [x] Commented complex or non-obvious code
- [x] Updated documentation (README, comments, etc.)
- [x] No secrets or sensitive data committed
- [x] Tested changes work as expected

## Related Issues

N/A

## Modified Files

- `docker/Dockerfile` — added `gh` CLI installation
- `docker/docker-compose.yml` — added `GH_TOKEN` to gateway environment
- `docker/.env.example` — added `GH_TOKEN` env var
- `config/skills-manifest.txt` — added `github` skill

## Companion PR

Infra repo changes (env var docs): [PLACEHOLDER_LINK]

## Usage

```bash
# In .env (or infra repo's secrets/openclaw.env):
GH_TOKEN=ghp_your_github_pat

# Deploy:
make push-env && make deploy
```
