### PR TITLE
Update default model to sonnet, bump OpenClaw version, and add uv

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -25,7 +25,7 @@
   "agents": {
     "defaults": {
       "model": {
-        "primary": "anthropic/claude-opus-4-6"
+        "primary": "anthropic/claude-sonnet-4-6"
       },
       "compaction": {
         "mode": "safeguard"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,11 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
   && apt-get update && apt-get install -y --no-install-recommends gh \
   && rm -rf /var/lib/apt/lists/*
 
+# Install uv (Python package/project manager)
+COPY --from=ghcr.io/astral-sh/uv:0.10.4 /uv /uvx /bin/
+
 # Pin OpenClaw version for reproducible builds — bump explicitly when upgrading
-ARG OPENCLAW_VERSION=2026.2.6-3
+ARG OPENCLAW_VERSION=v2026.2.22
 RUN npm install -g openclaw@${OPENCLAW_VERSION}
 
 # Install ClawHub CLI for skill management


### PR DESCRIPTION
## Summary
- Switch default agent model from `claude-opus-4-6` to `claude-sonnet-4-6`
- Bump OpenClaw version from `2026.2.6-3` to `v2026.2.22`
- Add `uv` (Python package/project manager) to Docker image

## Test plan
- [ ] Verify Docker image builds successfully with the new `uv` binary
- [ ] Confirm OpenClaw `v2026.2.22` installs correctly
- [ ] Validate agent defaults load `claude-sonnet-4-6` as the primary model

🤖 Generated with [Claude Code](https://claude.com/claude-code)