### PR TITLE
Fix Docker login command and update diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Docker configuration and application setup for OpenClaw. Companion repository to
 │              │  make push-env          │   Hetzner VPS        │
 │              │──── (infra repo) ──────▶│   ┌────────────────┐ │
 │              │  make deploy            │   │ Docker         │ │
-└──────────────┘                        │   │ openclaw-gw    │ │
-                                        │   └────────────────┘ │
-                                        │   :18789 (loopback)  │
-                                        └──────────────────────┘
+└──────────────┘                         │   │ openclaw-gw    │ │
+                                         │   └────────────────┘ │
+                                         │   :18789 (loopback)  │
+                                         └──────────────────────┘
 ```
 
 ## Prerequisites
@@ -51,7 +51,7 @@ specific files from your local checkout to the VPS:
 1. **In the infra repo**, set `CONFIG_DIR` in `config/inputs.sh` to point to this repo's directory
 2. **Log in to GHCR** (one-time, on your laptop):
    ```bash
-   echo "$GHCR_PAT" | docker login ghcr.io -u YOUR_GITHUB_USERNAME --password-stdin
+   echo "$GHCR_TOKEN" | docker login ghcr.io -u GHCR_USERNAME --password-stdin
    ```
 3. **Build and push the Docker image**:
    ```bash


### PR DESCRIPTION
This pull request updates the documentation to clarify the instructions for logging in to GHCR (GitHub Container Registry) when pushing Docker images. The change updates the environment variable and username placeholder to be more accurate and consistent.

- **Documentation update:**
  * In `README.md`, replaced the use of `$GHCR_PAT` and `YOUR_GITHUB_USERNAME` with `$GHCR_TOKEN` and `GHCR_USERNAME` in the Docker login command to standardize the environment variable names and placeholders.
  **Note: I think this was some change that happened along the way**