### PR TITLE
feat: per-agent workspace sync to separate GitHub repos

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -29,11 +29,13 @@ BRAVE_SEARCH_API_KEY=
 # Your GitHub username for pulling Docker images
 GHCR_USERNAME=
 
-# ─── Workspace Git Sync (optional) ──────────────────────────────────────────
-# Daily commit+push of ~/.openclaw/workspace to a private GitHub repo.
+# ─── Workspace Git Sync (optional, per-agent) ───────────────────────────────
+# Daily commit+push of each agent workspace to its own private GitHub repo.
 # Create a PAT at: github.com/settings/tokens with 'repo' scope
-# Auto-enables when GIT_WORKSPACE_REPO is set
-GIT_WORKSPACE_REPO=your-username/openclaw-workspace
+# Each agent syncs independently — leave a repo blank to skip that agent.
+GIT_WORKSPACE_REPO_MAIN=your-username/openclaw-workspace-main
+GIT_WORKSPACE_REPO_DEVELOPER=your-username/openclaw-workspace-developer
+GIT_WORKSPACE_REPO_XSG=your-username/openclaw-workspace-xsg
 GIT_WORKSPACE_BRANCH=auto
 GIT_WORKSPACE_TOKEN=
 # Cron schedule: minute hour day month weekday (default: daily at 4 AM UTC)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,15 +21,41 @@ services:
       - "127.0.0.1:${OPENCLAW_GATEWAY_PORT:-18789}:18789"
     command: openclaw gateway --bind lan --port 18789
 
-  workspace-sync:
+  workspace-sync-main:
     image: ghcr.io/${GHCR_USERNAME}/openclaw-docker-config/workspace-sync:latest
     restart: unless-stopped
     environment:
-      GIT_WORKSPACE_REPO: ${GIT_WORKSPACE_REPO:-}
+      GIT_WORKSPACE_REPO: ${GIT_WORKSPACE_REPO_MAIN:-}
       GIT_WORKSPACE_BRANCH: ${GIT_WORKSPACE_BRANCH:-auto}
       GIT_WORKSPACE_TOKEN: ${GIT_WORKSPACE_TOKEN:-}
       GIT_WORKSPACE_SYNC_SCHEDULE: ${GIT_WORKSPACE_SYNC_SCHEDULE:-0 4 * * *}
     volumes:
-      - ${OPENCLAW_WORKSPACE_DIR:-/home/openclaw/.openclaw/workspace}:/workspace
+      - ${OPENCLAW_WORKSPACE_DIR:-/home/openclaw/.openclaw/workspace}/main:/workspace
+    profiles:
+      - sync
+
+  workspace-sync-developer:
+    image: ghcr.io/${GHCR_USERNAME}/openclaw-docker-config/workspace-sync:latest
+    restart: unless-stopped
+    environment:
+      GIT_WORKSPACE_REPO: ${GIT_WORKSPACE_REPO_DEVELOPER:-}
+      GIT_WORKSPACE_BRANCH: ${GIT_WORKSPACE_BRANCH:-auto}
+      GIT_WORKSPACE_TOKEN: ${GIT_WORKSPACE_TOKEN:-}
+      GIT_WORKSPACE_SYNC_SCHEDULE: ${GIT_WORKSPACE_SYNC_SCHEDULE:-0 4 * * *}
+    volumes:
+      - ${OPENCLAW_WORKSPACE_DIR:-/home/openclaw/.openclaw/workspace}/developer:/workspace
+    profiles:
+      - sync
+
+  workspace-sync-xsg:
+    image: ghcr.io/${GHCR_USERNAME}/openclaw-docker-config/workspace-sync:latest
+    restart: unless-stopped
+    environment:
+      GIT_WORKSPACE_REPO: ${GIT_WORKSPACE_REPO_XSG:-}
+      GIT_WORKSPACE_BRANCH: ${GIT_WORKSPACE_BRANCH:-auto}
+      GIT_WORKSPACE_TOKEN: ${GIT_WORKSPACE_TOKEN:-}
+      GIT_WORKSPACE_SYNC_SCHEDULE: ${GIT_WORKSPACE_SYNC_SCHEDULE:-0 4 * * *}
+    volumes:
+      - ${OPENCLAW_WORKSPACE_DIR:-/home/openclaw/.openclaw/workspace}/xsg:/workspace
     profiles:
       - sync


### PR DESCRIPTION
## Summary
- Split the single `workspace-sync` container into 3 per-agent containers (`workspace-sync-main`, `workspace-sync-developer`, `workspace-sync-xsg`)
- Each container mounts only its agent's workspace subdirectory and syncs to its own GitHub repo
- Same Docker image, no script or Dockerfile changes needed

## Changes
- `docker/docker-compose.yml` — replace 1 service with 3, each mounting `workspace/{agent}` 
- `docker/.env.example` — update env vars to per-agent `GIT_WORKSPACE_REPO_*`

## Test plan
- [x] Deployed and verified all 3 containers start and run initial sync
- [x] Verified manual sync (`make workspace-sync`) iterates all containers
- [x] Verified cron is configured and `run-sync.sh` wrapper executes correctly
- [x] Confirmed each agent syncs to its own repo on the `auto` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)