### PR TITLE
feat: add multi-agent workspace sync example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -38,3 +38,5 @@ GIT_WORKSPACE_BRANCH=auto
 GIT_WORKSPACE_TOKEN=
 # Cron schedule: minute hour day month weekday (default: daily at 4 AM UTC)
 GIT_WORKSPACE_SYNC_SCHEDULE=0 4 * * *
+# For multi-agent setups, add per-agent repos (see docker-compose.yml):
+# GIT_WORKSPACE_REPO_SECOND=your-username/openclaw-workspace-second

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,3 +33,20 @@ services:
       - ${OPENCLAW_WORKSPACE_DIR:-/home/openclaw/.openclaw/workspace}:/workspace
     profiles:
       - sync
+
+  # For multi-agent setups, duplicate the workspace-sync service for each agent.
+  # The volume subdirectory must match the agent's workspace path in openclaw.json
+  # (e.g. "workspace": "~/.openclaw/workspace/second" → mount /second).
+  #
+  # workspace-sync-second:
+  #   image: ghcr.io/${GHCR_USERNAME}/openclaw-docker-config/workspace-sync:latest
+  #   restart: unless-stopped
+  #   environment:
+  #     GIT_WORKSPACE_REPO: ${GIT_WORKSPACE_REPO_SECOND:-}
+  #     GIT_WORKSPACE_BRANCH: ${GIT_WORKSPACE_BRANCH:-auto}
+  #     GIT_WORKSPACE_TOKEN: ${GIT_WORKSPACE_TOKEN:-}
+  #     GIT_WORKSPACE_SYNC_SCHEDULE: ${GIT_WORKSPACE_SYNC_SCHEDULE:-0 4 * * *}
+  #   volumes:
+  #     - ${OPENCLAW_WORKSPACE_DIR:-/home/openclaw/.openclaw/workspace}/second:/workspace
+  #   profiles:
+  #     - sync

--- a/docker/workspace-sync/workspace-sync.sh
+++ b/docker/workspace-sync/workspace-sync.sh
@@ -71,6 +71,10 @@ fi
 
 echo "[...] Checking for changes..."
 
+# Remove nested .git dirs created by OpenClaw's ensureGitRepo() in agent workspaces.
+# These break `git add -A` (git treats them as submodule refs without .gitmodules).
+find "$WORKSPACE_DIR" -mindepth 2 -name ".git" -type d -exec rm -rf {} + 2>/dev/null || true
+
 git add -A
 
 if git diff --cached --quiet; then


### PR DESCRIPTION
## Summary
- Fix nested `.git` dirs breaking workspace sync (strips them before `git add -A`)
- Add commented-out example for multi-agent workspace sync (one container per agent, each syncing to its own repo)

Fixes #9

## Changes
- `docker/workspace-sync/workspace-sync.sh` — add `find` to remove nested `.git` dirs before sync
- `docker/docker-compose.yml` — add commented example for a second workspace-sync container
- `docker/.env.example` — add commented `GIT_WORKSPACE_REPO_SECOND` example

Companion PR (terraform): https://github.com/andreesg/openclaw-terraform-hetzner/pull/12

## Test plan
- [x] Verified `find` cleanup removes nested `.git` dirs created by OpenClaw
- [x] Verified `git add -A` succeeds after cleanup (previously failed with `does not have a commit checked out`)
- [x] Tested full workspace sync to a test repo with all agent subdirectories
- [x] Tested multi-agent setup with separate containers syncing to separate repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)