### PR TITLE
Use already defined environment variables for bind address and port in docker compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - ${OPENCLAW_WORKSPACE_DIR:-/home/openclaw/.openclaw/workspace}:/home/node/.openclaw/workspace
     ports:
       - "127.0.0.1:${OPENCLAW_GATEWAY_PORT:-18789}:18789"
-    command: openclaw gateway --bind lan --port 18789
+    command: openclaw gateway --bind ${OPENCLAW_GATEWAY_BIND} --port ${OPENCLAW_GATEWAY_PORT}
 
   workspace-sync:
     image: ghcr.io/${GHCR_USERNAME}/openclaw-docker-config/workspace-sync:latest


### PR DESCRIPTION
This switches the command `openclaw gateway --bind lan --port 18789` to use the defined `OPENCLAW_GATEWAY_BIND` and `OPENCLAW_GATEWAY_PORT` variables.

Maybe the default of the environment variable should be set to `lan` as default?