### PR TITLE
Upgrade OpenClaw to v2026.4.9

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -1,7 +1,10 @@
 {
   "gateway": {
     "mode": "local",
-    "port": 18789
+    "port": 18789,
+    "controlUi": {
+      "allowedOrigins": ["http://localhost:18789"]
+    }
   },
 
   "channels": {
@@ -10,7 +13,7 @@
       "botToken": "${TELEGRAM_BOT_TOKEN}",
       "dmPolicy": "pairing",
       "groupPolicy": "allowlist",
-      "streamMode": "partial"
+      "streaming": "partial"
     }
   },
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
   && rm -rf /var/lib/apt/lists/*
 
 # Pin OpenClaw version for reproducible builds — bump explicitly when upgrading
-ARG OPENCLAW_VERSION=2026.2.6-3
+ARG OPENCLAW_VERSION=2026.4.9
 RUN npm install -g openclaw@${OPENCLAW_VERSION}
 
 # Install ClawHub CLI for skill management


### PR DESCRIPTION
This bumps the OpenClaw version from version `2026.2.6-3` to `2026.4.9` and updates the config.